### PR TITLE
Fix Marker not loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etchteam/storybook-addon-marker",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Add a Marker.io feedback button to the storybook UI",
   "main": "dist/manager.js",
   "files": [

--- a/preview.js
+++ b/preview.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/preview.js');

--- a/src/FeedbackButton.js
+++ b/src/FeedbackButton.js
@@ -43,8 +43,8 @@ export default function FeedbackButton() {
     <Button
       style={{
         height: '28px',
-        'margin-block-start': '6px',
-        'margin-inline-start': '4px',
+        marginBlockStart: '6px',
+        marginInlineStart: '4px',
       }}
       key={TOOL_ID}
       active={isActive}

--- a/src/FeedbackButton.js
+++ b/src/FeedbackButton.js
@@ -1,9 +1,9 @@
 import markerSDK from '@marker.io/browser';
 import { Button } from '@storybook/components';
-import { useGlobals, useParameter } from '@storybook/manager-api';
-import React, { useCallback, useEffect } from 'react';
+import { useParameter } from '@storybook/manager-api';
+import React, { useCallback, useEffect, useState } from 'react';
 
-import { WIDGET_KEY, TOOL_ID } from './constants';
+import { TOOL_ID } from './constants';
 
 const hideDefaultMarkerButton = () => {
   const markerBtns = [
@@ -13,12 +13,11 @@ const hideDefaultMarkerButton = () => {
 };
 
 export default function FeedbackButton() {
-  const [globals, updateGlobals] = useGlobals();
+  const [markerLoaded, setMarkerLoaded] = useState();
   const { destination, mode, ...config } = useParameter('marker', {});
-  const isActive = globals[WIDGET_KEY];
 
   useEffect(() => {
-    if (!destination || isActive) {
+    if (!destination || markerLoaded || window.Marker) {
       return;
     }
 
@@ -29,17 +28,15 @@ export default function FeedbackButton() {
       })
       .then(() => {
         hideDefaultMarkerButton();
-        updateGlobals({
-          [WIDGET_KEY]: true,
-        });
+        setMarkerLoaded(true);
       });
   }, [destination]);
 
   const handleSendFeedback = useCallback(() => {
     window.Marker?.capture(mode);
-  }, [mode, globals[WIDGET_KEY]]);
+  }, [mode]);
 
-  return isActive ? (
+  return markerLoaded ? (
     <Button
       style={{
         height: '28px',
@@ -47,7 +44,6 @@ export default function FeedbackButton() {
         marginInlineStart: '4px',
       }}
       key={TOOL_ID}
-      active={isActive}
       onClick={handleSendFeedback}
       outline
       small

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,2 @@
 export const ADDON_ID = 'marker';
 export const TOOL_ID = `${ADDON_ID}/tool`;
-export const WIDGET_KEY = 'markerFeedbackWidgetActive';

--- a/src/preview.js
+++ b/src/preview.js
@@ -1,9 +1,0 @@
-import { WIDGET_KEY } from './constants';
-
-const preview = {
-  globals: {
-    [WIDGET_KEY]: false,
-  },
-};
-
-export default preview;


### PR DESCRIPTION
The marker widget stopped loading in after storybook has rendered once because the global seems to get cached.

This removes use of globals to depend on state and marker being present on the window instead.