### PR TITLE
Fix feedback button style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etchteam/storybook-addon-marker",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Add a Marker.io feedback button to the storybook UI",
   "main": "dist/manager.js",
   "files": [

--- a/src/FeedbackButton.js
+++ b/src/FeedbackButton.js
@@ -1,9 +1,29 @@
 import markerSDK from '@marker.io/browser';
-import { Button } from '@storybook/components';
+import { Icons, IconButton } from '@storybook/components';
 import { useParameter } from '@storybook/manager-api';
+import { styled } from '@storybook/theming';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { TOOL_ID } from './constants';
+
+const IconButtonWithLabel = styled(IconButton)(() => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+}));
+
+const IconButtonLabel = styled.div(({ theme }) => ({
+  display: 'inline-block',
+  textDecoration: 'none',
+  padding: '10px 5px',
+  fontWeight: theme.typography.weight.bold,
+  fontSize: theme.typography.size.s2 - 1,
+  lineHeight: '1',
+  height: 37,
+  border: 'none',
+  borderTop: '3px solid transparent',
+  borderBottom: '3px solid transparent',
+  background: 'transparent',
+}));
 
 const hideDefaultMarkerButton = () => {
   const markerBtns = [
@@ -37,18 +57,9 @@ export default function FeedbackButton() {
   }, [mode]);
 
   return markerLoaded ? (
-    <Button
-      style={{
-        height: '28px',
-        marginBlockStart: '6px',
-        marginInlineStart: '4px',
-      }}
-      key={TOOL_ID}
-      onClick={handleSendFeedback}
-      outline
-      small
-    >
-      Feedback
-    </Button>
+    <IconButtonWithLabel key={TOOL_ID} onClick={handleSendFeedback}>
+      <Icons icon="comment" />
+      <IconButtonLabel>Feedback</IconButtonLabel>
+    </IconButtonWithLabel>
   ) : null;
 }


### PR DESCRIPTION
Depending on the theme, the button could be hard to spot:

<img width="110" alt="Screenshot 2024-02-08 at 17 28 04" src="https://github.com/etchteam/storybook-addon-marker/assets/5038459/fa17bd59-927c-4475-88e7-3a062e27118a">

This changes the button to use an IconButton provided by Storybook, same as the other IconButtons in the toolbar, the  styles are taken from [@etchteam/storybook-addon-css-variables-theme](https://github.com/etchteam/storybook-addon-css-variables-theme/blob/main/src/register.tsx) 

<img width="282" alt="Screenshot 2024-02-08 at 17 26 52" src="https://github.com/etchteam/storybook-addon-marker/assets/5038459/62771e7b-b4ea-48dc-929e-31780bfbbd38">
<img width="295" alt="Screenshot 2024-02-08 at 17 27 02" src="https://github.com/etchteam/storybook-addon-marker/assets/5038459/cdf93a69-3997-497c-9311-7613f41fa00e">
